### PR TITLE
Discoverability features and back to old glory (temporary hacks to get working)

### DIFF
--- a/python-interface/src/MiniBotFramework/Communication/UDP.py
+++ b/python-interface/src/MiniBotFramework/Communication/UDP.py
@@ -1,6 +1,6 @@
 # UDP code taken from < https://pymotw.com/2/socket/udp.html >
 
-import socket, time
+import socket, time, fcntl, struct
 
 def udpBeacon():
 	# Create a UDP socket
@@ -8,14 +8,14 @@ def udpBeacon():
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-    my_ip = str(socket.gethostbyname(socket.gethostname()))
+    my_ip = getIP('wlan0')
     spliced_subnet = my_ip[:my_ip.rfind('.')] + ".255"
 
-	# Define broadcasting address and message
+        # Define broadcasting address and message
     server_address = (spliced_subnet, 5001)
     message = 'Hello, I am a minibot!'
-
-	# Send message and resend every 9 seconds
+        
+        # Send message and resend every 9 seconds
     while True:
         try:
 		    # Send data
@@ -24,3 +24,15 @@ def udpBeacon():
         except Exception as err:
             print(err)
         time.sleep(9)
+
+def getIP(ifname):
+    """
+    Returns the IP of the device
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    return socket.inet_ntoa(fcntl.ioctl(
+        s.fileno(),
+        0x8915,  # SIOCGIFADDR
+        struct.pack('256s', ifname[:15])
+        )[20:24])
+

--- a/python-interface/src/MiniBotFramework/Controls/Xbox.py
+++ b/python-interface/src/MiniBotFramework/Controls/Xbox.py
@@ -1,10 +1,6 @@
 
-<<<<<<< HEAD
-from Lib.legopi.lib import xbox_read
-=======
 #Reads xbox inputs and returns desired l/r wheel powers
-from MiniBotFramework.Controls.Lib.legopi.lib import xbox_read
->>>>>>> may6
+from MiniBotFramework.Lib.legopi.lib import xbox_read
 from threading import Thread
 
 class Xbox(object):

--- a/python-interface/src/MiniBotFramework/Controls/__init__.py
+++ b/python-interface/src/MiniBotFramework/Controls/__init__.py
@@ -1,2 +1,2 @@
 import MiniBotFramework.Controls.Xbox
-import MiniBotFramework.Controls.Lib
+import MiniBotFramework.Lib

--- a/python-interface/src/MiniBotFramework/Lib/__init__.py
+++ b/python-interface/src/MiniBotFramework/Lib/__init__.py
@@ -1,1 +1,1 @@
-import MiniBotFramework.Lib.minibot_tools
+# import MiniBotFramework.Lib.minibot_tools

--- a/python-interface/src/MiniBotScripts/SwarmMaster.py
+++ b/python-interface/src/MiniBotScripts/SwarmMaster.py
@@ -6,6 +6,7 @@ from MiniBotFramework.Sensing.ColorSensor import ColorSensor
 import time
 
 threads = []
+count = {"F":0,"B":0,"L":0,"R":0}
 
 def run(bot):
     # Sets up TCP connection between master and minions. Starts publisher-side 
@@ -30,8 +31,7 @@ def colorbot(bot,z):
     cs.calibrate()
     pinkFirstTime = True
     orangeFirstTime = True
-    count = {"F":0,"B":0,"L":0,"R":0}
-
+    
     try:
         while(True):
             c = cs.read_color()


### PR DESCRIPTION
1. **discoverability**: the bot was fetching the local address (192.168.0.1) instead of the network IP address, which was not showing up in the base station. Fixed it by using a getIP function in the UDP file, similar to the one in the ZMQ file.
2. **import errors in python-interface**: prob broke due to a bunch of PRs in the end of last semester. Fixed those that I encountered.
3. **other small fixes** - most of them are inconsequential
-----
Didn't see any error in the platform or basestation