### PR TITLE
Minor QOL fixes to old GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ config.json
 UserScript.py
 *.log
 classes
+node_modules/

--- a/cs-minibot-platform-src/src/main/resources/public/css/general.css
+++ b/cs-minibot-platform-src/src/main/resources/public/css/general.css
@@ -47,12 +47,7 @@ button:hover { background:#DBDBDB; }
 .box button {
 	background:#ffffff;
 }
-.dir#cw, .dir#ccw {
-	background:#D0DBD2;
-}
-.dir#log {
-    background:#98AFC7;
-}
+
 #view:after {
 	content:"";
 }
@@ -61,15 +56,16 @@ button:hover { background:#DBDBDB; }
       background:#000000;
       color:white;
       border:1px solid gray;
-      margin:50px 0 0 10vw;
       overflow:scroll;
-      border-radius:10px;
       font-family:Consolas, monospace;
       padding:10px;
       font-size:12px;
     }
-    #run {
-      background:white;
-      padding:10px;
-      font-family:Consolas, monospace;
-    }
+#run {
+  background:white;
+  padding:10px;
+  font-family:Consolas, monospace;
+}
+.controlgrid{
+	padding:10px;
+}

--- a/cs-minibot-platform-src/src/main/resources/public/css/general2.css
+++ b/cs-minibot-platform-src/src/main/resources/public/css/general2.css
@@ -88,7 +88,6 @@ body {
 /*
  * Placeholder dashboard ideas
  */
-
 .placeholders {
   margin-bottom: 30px;
   text-align: center;

--- a/cs-minibot-platform-src/src/main/resources/public/gui/index.html
+++ b/cs-minibot-platform-src/src/main/resources/public/gui/index.html
@@ -40,10 +40,10 @@
 			<div class="well view">
 				<h4>View:
 					<input type="checkbox" id="vision-poll"> Poll for Vision Data<br>
-					Scale (10-100%): <input id="scale" type="range" name="power" min="10" max="100" value="100">
+					Scale (10-100%): <input style="width:10vw;" id="scale" type="range" name="power" min="10" max="100" value="100">
 				</h4>
 				<br>
-				<div id="view"></div>
+				<div id="view" style="min-height:550px;"></div>
 			</div>
 		</div>
 		<div class="col-md-5">
@@ -72,8 +72,8 @@
 				</select>
 
 				<button class="controls" id="removeBot">remove</button><br>
-				Power (0-100): <input id="power" type="range" name="power" min="0" max="100" value="50">
-				<br><hr><br>
+				Power (0-100): <input id="power" style="width:10vw;" type="range" name="power" min="0" max="100" value="50">
+				<br>
 				<b>Directions:</b><br>
 				<table style="text-align:center;">
 					<tr>

--- a/cs-minibot-platform-src/src/main/resources/public/gui/index.html
+++ b/cs-minibot-platform-src/src/main/resources/public/gui/index.html
@@ -5,187 +5,163 @@
 	<!-- IMPORTS -->
 	<link rel="stylesheet" href="../css/general.css"/>
 	<link rel="stylesheet" href="../css/vendor/prettify/prettify.css">
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 	<!-- END IMPORTS -->
 </head>
 
 <body>
 	<header>
-		<h1>modbot gui v2.0</h1><br>
-		A GUI to control Cornell Cup's modbot.
+		<h1>MiniBot GUI v2.0.1</h1><br>
+		A GUI to control Cornell Cup's Minibot.
 	</header>
 
-	<!-- BOT VIEW -->
-	<div class="box view">
-		<h3>VIEW
-			<!--<button id="zoom-out">scale view</button>
-			<button id="reset">reset</button>-->
-			<input type="checkbox" id="vision-poll"> Poll for Vision Data<br>
-			Scale (10-100%): <input id="scale" type="range" name="power" min="10" max="100" value="100">
-		</h3>
-		<table>
-			<tr>
-				<td>
-					Scale: <br>
-					&nbsp; &nbsp; x: [0,12]<br>
-					&nbsp; &nbsp; y: [0,12]<br>
-				</td>
-				<td>&nbsp; &nbsp; &nbsp; </td>
-				<td>
-					Interval: <br>
-					&nbsp; &nbsp; x spacing: <span id="x-int"></span><br>
-					&nbsp; &nbsp; y spacing: <span id="y-int"></span>
-				</td>
-			</tr>
-		</table>
-		<br><br>
-		<div id="view">
-		<!-- this is where the grid goes -->
+	<!-- COLUMNS -->
+	<div class="row">
+		<div class="col-md-5 col-md-offset-1">
+			<!-- ADDBOT -->
+			<div class="well">
+				<h4>Add a bot:</h4>
+				IP: <input type="text" name="ip" id="ip"><br/>
+				Port: <input type="text" name="port" id="port" value="10000"><br/>
+				Name: <input type="text" name="name" id="name"><br/>
+				Type:
+				<select id="bot-type" name="type">
+					<option value="minibot">minibot</option>
+					<option value="modbot">modbot</option>
+					<option value = "simulator.simbot">simulator.simbot</option>
+				</select>
+				<button id="addBot">add bot</button>
+				<button id = "updateLocs"> Run simulator </button>
+				<br>
+				<h4>Add a discovered bot:</h4>
+				<div id="discovered"></div>
+			</div>
+			<!-- VIEW -->
+			<div class="well view">
+				<h4>View:
+					<input type="checkbox" id="vision-poll"> Poll for Vision Data<br>
+					Scale (10-100%): <input id="scale" type="range" name="power" min="10" max="100" value="100">
+				</h4>
+				<br>
+				<div id="view"></div>
+			</div>
+		</div>
+		<div class="col-md-5">
+			<!-- SCENARIOS -->
+			<div class="well">
+				<h4>Scenarios:</h4><br>
+				Scenario name:<input type="text" id="scenarioname"
+									 value="scenario1"><br>
+				Scenario viewer: <textarea rows="4" cols="90" name="scenario"
+										   id="scenario" style="display:block">[{"type":	"simulator.simbot",
+		"position":"[2,2]", "angle":0},{"type":	"scenario_object",
+		"position":"[5,5]", "angle":45, "size":1},{"type": "scenario_object", "position":"[3,3]", "angle":45, "size": 1}]</textarea>
+				<button id="addScenario">add scenario to world</button>
+				<button id="loadScenario">load scenario from file</button>
+				<button id="saveScenario">save scenario to file</button>
+				<br>
+				<button id = "showOccupancyMatrix">Occupancy Matrix</button>
+			</div>
+			<!-- CONTROLS -->
+			<div class="well">
+				<h4>Movement controls:</h4>
+				Choose bot:<br>
+				<select id="botlist" name="bots">
+					<option value="">-- Choose a bot --</option>
+					<option value="0">(DEBUG) Sim Bot</option>
+				</select>
+
+				<button class="controls" id="removeBot">remove</button><br>
+				Power (0-100): <input id="power" type="range" name="power" min="0" max="100" value="50">
+				<br><hr><br>
+				<b>Directions:</b><br>
+				<table style="text-align:center;">
+					<tr>
+						<td class="controlgrid"><button class="btn" id="ccw">turn CCW</button></td>
+						<td class="controlgrid"><button class="btn" id="fwd">forward</button></td>
+						<td class="controlgrid"><button class="btn" id="cw">turn CW</button></td>
+					</tr>
+					<tr>
+						<td class="controlgrid"><button class="btn" id="lft">left</button></td>
+						<td class="controlgrid"><button class="btn btn-danger" id="stop" style="background:red;">STOP</button></td>
+						<td class="controlgrid"><button class="btn" id="rt">right</button></td>
+					</tr>
+					<tr>
+						<td class="controlgrid"><button class="btn btn-success" id="log">log data</button></td>
+						<td class="controlgrid"><button class="btn" id="bck">backward</button></td>
+						<td class="controlgrid"></td>
+					</tr>
+					<tr>
+						<td></td>
+						<td>
+							<input type="checkbox" id="keyboard-controls"> Enable Keyboard Controls
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td><button id="xbox-on">Start Xbox</td>
+						<td><button id="xbox-off">Stop Xbox</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td><input type="text" id="kv_key" placeholder="Key (e.g. WHEELS)"></td>
+						<td><input type="text" id="kv_value" placeholder="Value (e.g. 10,10)"></td>
+						<td><button id="sendkv" onclick="sendKV()">Send KV</button></td>
+					</tr>
+				</table>
+			</div>
+		</div>
+	</div>
+	<br>
+	<div class = "row">
+		<div class= "col-md-6">
+			<div id="blocklyDiv" style="margin:0; margin-left:3.5%; height:80vh; width: 50vw;"></div>
+		</div>
+		<div class= "col-md-6">
+			<!-- BEGINNING OF BLOCKLY CODE -->
+			<div class="box" style = "padding: 0; margin-top: 0">
+				<!-- BLOCKLY TOOLBOX -->
+				<!--<div id="blocklyDiv" style="margin:0; height: 60vh; width: 80vw;"></div>-->
+				<xml id="toolbox" style="display:none;">
+					<block type="controls_if"></block>
+					<block type="variables_set"></block>
+					<block type="variables_get"></block>
+					<block type="logic_compare"></block>
+					<block type="controls_repeat_ext"></block>
+					<block type="math_number"></block>
+					<block type="math_arithmetic"></block>
+					<block type="text"></block>
+					<block type="text_print"></block>
+
+					<!-- ADDING CUSTOM BLOCKS -->
+					<block type="move"></block>
+					<block type="turn"></block>
+					<block type="setwheelpower"></block>
+					<block type="wait"></block>
+				</xml>
+
+				<!-- SUBMIT/DOWNLOAD/UPLOAD FUNCTIONALITIES -->
+				<!-- download script-->
+				<form id="dwn" onsubmit="download(this['name'].value, this['text'].value)">
+					<input type="text" name="name" value="myBlocklyCode.py">
+					<textarea name="text" size="100" cols="100" rows="40" name="data" id="data"></textarea><br>
+					<input type="submit" value="Download">
+				</form>
+				<!-- send script -->
+				<input type="submit" value="Run" id="send"><br>
+				<!-- upload script -->
+				<form type=POST>
+					<input
+							type="file"
+							id="upload"
+							multipleSize="1"
+							accept=".py"
+					/>
+				</form>
+			</div>
 		</div>
 	</div>
 
-
-	<!-- BOT CONTROLS -->
-	<div class="box">
-		<h4>Movement controls:</h4>
-		Choose bot:<br>
-		<select id="botlist" name="bots">
-			<option value="">-- Choose a bot --</option>
-			<option value="0">(DEBUG) Sim Bot</option>
-		</select>
-
-		<button class="controls" id="removeBot">remove</button><br>
-		Power (0-100): <input id="power" type="range" name="power" min="0" max="100" value="50">
-		<br><br>
-		
-		<hr><br>
-
-		<b>Directions:</b><br>
-
-		<table style="text-align:center;">
-			<tr>
-				<td><button class="dir" id="ccw">turn CCW</button></td>
-				<td><button class="dir" id="fwd">forward</button></td>
-				<td><button class="dir" id="cw">turn CW</button></td>
-			</tr>
-			<tr>
-				<td><button class="dir" id="lft">left</button></td>
-				<td><button class="dir" id="stop" style="background:red;">STOP</button></td>
-				<td><button class="dir" id="rt">right</button></td>
-			</tr>
-			<tr>
-				<td><button class="dir" id="log">log data</button></td>
-				<td><button class="dir" id="bck">backward</button></td>
-				<td></td>
-			</tr>
-			<tr>
-				<td></td>
-				<td>
-					<input type="checkbox" id="keyboard-controls"> Enable Keyboard Controls
-				</td>
-				<td></td>
-			</tr>
-			<tr>
-				<td><button id="xbox-on">Start Xbox</td>
-				<td><button id="xbox-off">Stop Xbox</td>
-				<td></td>
-			</tr>
-			<tr>
-				<td><input type="text" id="kv_key" placeholder="Key (e.g. WHEELS)"></td>
-				<td><input type="text" id="kv_value" placeholder="Value (e.g. 10,10)"></td>
-				<td><button id="sendkv" onclick="sendKV()">Send KV</button></td>
-			</tr>
-		</table>
-	</div>
-
-	<!-- BOT CONFIGURATIONS -->
-	<div class="box">
-		<h4>Add a bot:</h4>
-		IP: <input type="text" name="ip" id="ip"><br/>
-		Port: <input type="text" name="port" id="port" value="10000"><br/>
-		Name: <input type="text" name="name" id="name"><br/>
-		Type:
-		<select id="bot-type" name="type">
-			<option value="minibot">minibot</option>
-			<option value="modbot">modbot</option>
-			<option value = "simulator.simbot">simulator.simbot</option>
-		</select>
-		<button id="addBot">add bot</button>
-		<button id = "updateLocs"> Run simulator </button>
-		<br><hr><br>
-
-		Scenarios - obstacles only, add bot separately
-		Scenario name:<input type="text" id="scenarioname"
-							 value="scenario1"><br>
-		Scenario viewer: <textarea rows="4" cols="90" name="scenario"
-					   id="scenario" style="display:block">[{"type":	"simulator.simbot",
-		"position":"[2,2]", "angle":0},{"type":	"scenario_object",
-		"position":"[5,5]", "angle":45, "size":1},{"type": "scenario_object", "position":"[3,3]", "angle":45, "size": 1}]</textarea>
-		<button id="addScenario" style="float:left;margin-left:0">add scenario to world</button>
-		<button id="loadScenario">load scenario from file</button>
-		<br>
-		<button id = "showOccupancyMatrix">Occupancy Matrix</button>
-
-		<button id="saveScenario" style="float:right;margin-right: 0;">save scenario to file</button>
-	</div>
-
-	<div class="box">
-		<h4>Add a discovered bot:</h4>
-		<div id="discovered"></div>
-	</div>
-
-	<!--<div class="box">-->
-		<!--<h4>Active bots:</h4>-->
-		<!--<div id="active"></div>-->
-	<!--</div>-->
-
-	<div class="box">
-
-	<div id="blocklyDiv" style="margin:0; margin-left:3.5%; height: 60vh; width: 80vw;"></div>
-
-	<!-- BEGINNING OF BLOCKLY CODE -->
-	<div class="box" style = "padding: 0; margin-top: 0">
-		<!-- BLOCKLY TOOLBOX -->
-		<!--<div id="blocklyDiv" style="margin:0; height: 60vh; width: 80vw;"></div>-->
-		<xml id="toolbox" style="display:none;">
-			<block type="controls_if"></block>
-            <block type="variables_set"></block>
-            <block type="variables_get"></block>
-			<block type="logic_compare"></block>
-			<block type="controls_repeat_ext"></block>
-			<block type="math_number"></block>
-			<block type="math_arithmetic"></block>
-			<block type="text"></block>
-			<block type="text_print"></block>
-
-			<!-- ADDING CUSTOM BLOCKS -->
-			<block type="move"></block>
-			<block type="turn"></block>
-			<block type="setwheelpower"></block>
-			<block type="wait"></block>
-		</xml>
-
-		<!-- SUBMIT/DOWNLOAD/UPLOAD FUNCTIONALITIES -->
-			<!-- download script-->
-		<form id="dwn" onsubmit="download(this['name'].value, this['text'].value)">
-			<input type="text" name="name" value="myBlocklyCode.py">
-			<textarea name="text" size="100" cols="100" rows="10" name="data" id="data"></textarea><br/>
-			<input type="submit" value="Download">
-		</form>
-
-			<!-- send script -->
-		<button id="send">run</button>
-
-			<!-- upload script -->
-		<form type=POST>
-			<input
-				type="file"
-				id="upload"
-				multipleSize="1"
-				accept=".py"
-			/>
-		</form>
-	</div>
-	
 	<!-- basic imports -->
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 	<script src="http://pixijs.download/release/pixi.min.js"></script>
@@ -203,7 +179,7 @@
 	<script type="text/javascript" src="../js/blocks/custom_json.js"></script>
 
 	<!-- manual scripts -->
-	<script src="../js/blockly.js"></script>	
+	<script src="../js/blockly.js"></script>
 	<script src="../js/interface.js"></script>
 	<script src="../js/view.js"></script>
 </body>


### PR DESCRIPTION
Intended as a stopgap fix while new React GUI is being worked on.

I essentially made the old GUI layout look more similar to how the new GUI will be, minus the tabs, by throwing out a lot of old styling and replacing it with Bootstrap. No changes were made to functionality.

This should make the GUI easier to use for the Blockly team and anyone else that needs to use the GUI.
After this is approved everyone should pull these changes.

![mini_gui_update](https://user-images.githubusercontent.com/18299205/31421707-e96bcc4e-ae16-11e7-9a01-d20cd0ffb935.png)
![mini_gui_update_2](https://user-images.githubusercontent.com/18299205/31421708-e97ae224-ae16-11e7-844f-83803bd2010d.png)

